### PR TITLE
Egd and osdf-config fixes

### DIFF
--- a/src/main/java/io/osdf/actions/system/install/ScriptInstaller.java
+++ b/src/main/java/io/osdf/actions/system/install/ScriptInstaller.java
@@ -37,6 +37,6 @@ public class ScriptInstaller implements FileReplacer {
                 "then\n" +
                 "        trap '' SIGINT\n" +
                 "fi\n" +
-                pathToJava() + " -XX:TieredStopAtLevel=1 -jar " + paths.root() + "/osdf.jar ${@:1}";
+                pathToJava() + " -Djava.security.egd=file:/dev/./urandom -XX:TieredStopAtLevel=1 -jar " + paths.root() + "/osdf.jar ${@:1}";
     }
 }

--- a/src/main/java/io/osdf/settings/OsdfConfig.java
+++ b/src/main/java/io/osdf/settings/OsdfConfig.java
@@ -37,7 +37,11 @@ public class OsdfConfig {
     }
 
     public Integer maxParallel() {
-        return castToInteger(appProperty("osdf.deploy.maxParallel"));
+        try {
+            return castToInteger(appProperty("osdf.deploy.maxParallel"));
+        } catch (OSDFException e) {
+            return null;
+        }
     }
 
     private String appProperty(String key) {

--- a/src/test/java/io/osdf/settings/OsdfConfigTest.java
+++ b/src/test/java/io/osdf/settings/OsdfConfigTest.java
@@ -5,8 +5,7 @@ import io.osdf.common.exceptions.OSDFException;
 import io.osdf.core.local.microconfig.property.PropertyGetter;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -19,6 +18,15 @@ class OsdfConfigTest {
 
         OsdfConfig config = new OsdfConfig(getter);
         assertThrows(OSDFException.class, config::group);
+    }
+
+    @Test
+    void returnDefaults_ifPropertiesComponentDoesntExist() {
+        PropertyGetter getter = mock(PropertyGetter.class);
+        when(getter.get(any(), any(), any())).thenThrow(new ComponentNotFoundException("osdf-config"));
+
+        OsdfConfig config = new OsdfConfig(getter);
+        assertEquals(null, config.maxParallel());
     }
 
     @Test


### PR DESCRIPTION
* add -Djava.security.egd=file:/dev/./urandom option
* make osdf-config optional (remove requirement for maxParallel option, return default option instead)