### PR TITLE
Implement external variables injection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 group 'io.microconfig.osdf'
 
-version '1.6.4'
+version '1.6.5'
 
 sourceCompatibility = 11
 

--- a/src/main/java/io/osdf/actions/configs/ConfigsApiImpl.java
+++ b/src/main/java/io/osdf/actions/configs/ConfigsApiImpl.java
@@ -36,7 +36,7 @@ public class ConfigsApiImpl implements ConfigsApi {
     @Override
     public void env(String env) {
         configsUpdater(paths, cli)
-                .setConfigsParameters(env, null)
+                .setConfigsParameters(env, null, null)
                 .buildConfigs();
     }
 

--- a/src/main/java/io/osdf/actions/configs/versions/VersionsCommand.java
+++ b/src/main/java/io/osdf/actions/configs/versions/VersionsCommand.java
@@ -36,7 +36,7 @@ public class VersionsCommand {
     private void setVersionsForAllApps(String configVersion, String projectVersion) {
         setConfigVersion(configVersion);
         configsUpdater(paths, cli)
-                .setConfigsParameters(null, projectVersion)
+                .setConfigsParameters(null, projectVersion, null)
                 .fetch();
     }
 
@@ -49,7 +49,7 @@ public class VersionsCommand {
 
         ComponentDir componentDir = componentsLoader()
                 .loadOne(app, componentsFinder(paths.componentsPath()));
-        componentPostProcessor().process(componentDir);
+        componentPostProcessor(paths).process(componentDir);
     }
 
     private void setConfigVersion(String configVersion) {

--- a/src/main/java/io/osdf/actions/init/InitializationApi.java
+++ b/src/main/java/io/osdf/actions/init/InitializationApi.java
@@ -13,7 +13,8 @@ public interface InitializationApi {
     @Description("Set config parameters")
     @Arg(optional = "env", d = "Env name")
     @Arg(optional = "pv/projectVersion", d = "Project version")
-    void configs(String env, String projVersion);
+    @Arg(optional = "ext/external", d = "External variables path to yaml file")
+    void configs(String env, String projVersion, String externalPath);
 
     @Description("Initialize git configs")
     @Arg(optional = "url", d = "Url with credentials")

--- a/src/main/java/io/osdf/actions/init/InitializationApiImpl.java
+++ b/src/main/java/io/osdf/actions/init/InitializationApiImpl.java
@@ -70,9 +70,9 @@ public class InitializationApiImpl implements InitializationApi {
     }
 
     @Override
-    public void configs(String env, String projVersion) {
+    public void configs(String env, String projVersion, String externalPath) {
         configsUpdater(paths, cli)
-                .setConfigsParameters(env, projVersion)
+                .setConfigsParameters(env, projVersion, externalPath)
                 .buildConfigs();
     }
 

--- a/src/main/java/io/osdf/actions/init/configs/ConfigsUpdater.java
+++ b/src/main/java/io/osdf/actions/init/configs/ConfigsUpdater.java
@@ -46,9 +46,10 @@ public class ConfigsUpdater {
         fetch();
     }
 
-    public ConfigsUpdater setConfigsParameters(String env, String projectVersion) {
+    public ConfigsUpdater setConfigsParameters(String env, String projectVersion, String externalPath) {
         settingsFile.setIfNotNull(ConfigsSettings::setEnv, env);
         settingsFile.setIfNotNull(ConfigsSettings::setProjectVersion, projectVersion);
+        settingsFile.setIfNotNull(ConfigsSettings::setExternalPath, externalPath);
         settingsFile.save();
         return this;
     }
@@ -74,7 +75,7 @@ public class ConfigsUpdater {
         propertySetter().setIfNecessary(paths.projectVersionPath(), "project.version", settings.getProjectVersion());
         microConfig(settings.getEnv(), paths).generateConfigs(emptyList());
 
-        AppPostProcessor appPostProcessor = componentPostProcessor();
+        AppPostProcessor appPostProcessor = componentPostProcessor(paths);
         componentsLoader()
                 .load(componentsFinder(paths.componentsPath()), isApp())
                 .forEach(appPostProcessor::process);

--- a/src/main/java/io/osdf/actions/init/configs/postprocess/AppPostProcessor.java
+++ b/src/main/java/io/osdf/actions/init/configs/postprocess/AppPostProcessor.java
@@ -2,7 +2,6 @@ package io.osdf.actions.init.configs.postprocess;
 
 import io.osdf.actions.init.configs.postprocess.metadata.MetadataCreator;
 import io.osdf.actions.init.configs.postprocess.template.ResourceTemplatePostProcessor;
-import io.osdf.actions.init.configs.preprocess.ExternalVariablesResolver;
 import io.osdf.core.local.component.ComponentDir;
 import io.osdf.settings.paths.OsdfPaths;
 import lombok.RequiredArgsConstructor;
@@ -11,7 +10,7 @@ import static io.osdf.actions.init.configs.postprocess.ConfigMapCreator.configMa
 import static io.osdf.actions.init.configs.postprocess.ResourceSplitter.resourceSplitter;
 import static io.osdf.actions.init.configs.postprocess.template.ResourceTemplatePostProcessor.resourceTemplatePostProcessor;
 import static io.osdf.actions.init.configs.postprocess.metadata.MetadataCreatorImpl.metadataCreator;
-import static io.osdf.actions.init.configs.preprocess.ExternalVariablesResolver.externalVariablesResolver;
+import static io.osdf.actions.init.configs.postprocess.ExternalVariablesResolver.externalVariablesResolver;
 import static io.osdf.common.utils.FileUtils.createDirectoryIfNotExists;
 
 @RequiredArgsConstructor

--- a/src/main/java/io/osdf/actions/init/configs/postprocess/AppPostProcessor.java
+++ b/src/main/java/io/osdf/actions/init/configs/postprocess/AppPostProcessor.java
@@ -2,26 +2,33 @@ package io.osdf.actions.init.configs.postprocess;
 
 import io.osdf.actions.init.configs.postprocess.metadata.MetadataCreator;
 import io.osdf.actions.init.configs.postprocess.template.ResourceTemplatePostProcessor;
+import io.osdf.actions.init.configs.preprocess.ExternalVariablesResolver;
 import io.osdf.core.local.component.ComponentDir;
+import io.osdf.settings.paths.OsdfPaths;
+import lombok.RequiredArgsConstructor;
 
 import static io.osdf.actions.init.configs.postprocess.ConfigMapCreator.configMapCreator;
 import static io.osdf.actions.init.configs.postprocess.ResourceSplitter.resourceSplitter;
 import static io.osdf.actions.init.configs.postprocess.template.ResourceTemplatePostProcessor.resourceTemplatePostProcessor;
 import static io.osdf.actions.init.configs.postprocess.metadata.MetadataCreatorImpl.metadataCreator;
+import static io.osdf.actions.init.configs.preprocess.ExternalVariablesResolver.externalVariablesResolver;
 import static io.osdf.common.utils.FileUtils.createDirectoryIfNotExists;
 
+@RequiredArgsConstructor
 public class AppPostProcessor {
     private final ConfigMapCreator configMapCreator = configMapCreator();
     private final MetadataCreator metadataCreator = metadataCreator();
     private final ResourceSplitter resourceSplitter = resourceSplitter();
     private final ResourceTemplatePostProcessor resourceTemplatePostProcessor = resourceTemplatePostProcessor();
+    private final ExternalVariablesResolver externalVariablesResolver;
 
-    public static AppPostProcessor componentPostProcessor() {
-        return new AppPostProcessor();
+    public static AppPostProcessor componentPostProcessor(OsdfPaths paths) {
+        return new AppPostProcessor(externalVariablesResolver(paths));
     }
 
     public void process(ComponentDir componentDir) {
         createDirectoryIfNotExists(componentDir.getPath("resources"));
+        externalVariablesResolver.resolve(componentDir.root());
         resourceSplitter.splitResources(componentDir);
         configMapCreator.createConfigMaps(componentDir);
         metadataCreator.create(componentDir);

--- a/src/main/java/io/osdf/actions/init/configs/postprocess/ExternalVariablesResolver.java
+++ b/src/main/java/io/osdf/actions/init/configs/postprocess/ExternalVariablesResolver.java
@@ -1,4 +1,4 @@
-package io.osdf.actions.init.configs.preprocess;
+package io.osdf.actions.init.configs.postprocess;
 
 import io.osdf.common.exceptions.OSDFException;
 import io.osdf.common.exceptions.PossibleBugException;
@@ -57,8 +57,9 @@ public class ExternalVariablesResolver {
     private String getValue(String content, int startInd, int commaInd, int endInd) {
         String key = content.substring(startInd + 1, commaInd == -1 ? endInd : commaInd).trim();
         String defaultValue = commaInd != -1 ? content.substring(commaInd + 1, endInd).trim() : null;
-        return Stream.of(variables.get(key), defaultValue)
+        return Stream.of(variables.<Object>get(key), defaultValue)
                 .filter(Objects::nonNull)
+                .map(String::valueOf)
                 .findFirst()
                 .orElseThrow(() -> new OSDFException("External variable required for " + key));
     }

--- a/src/main/java/io/osdf/actions/init/configs/preprocess/ExternalVariablesResolver.java
+++ b/src/main/java/io/osdf/actions/init/configs/preprocess/ExternalVariablesResolver.java
@@ -1,0 +1,65 @@
+package io.osdf.actions.init.configs.preprocess;
+
+import io.osdf.common.exceptions.OSDFException;
+import io.osdf.common.exceptions.PossibleBugException;
+import io.osdf.common.yaml.YamlObject;
+import io.osdf.core.local.configs.ConfigsSettings;
+import io.osdf.settings.paths.OsdfPaths;
+import lombok.RequiredArgsConstructor;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import static io.osdf.common.SettingsFile.settingsFile;
+import static io.osdf.common.utils.FileUtils.readAll;
+import static io.osdf.common.utils.FileUtils.writeStringToFile;
+import static io.osdf.common.yaml.YamlObject.yaml;
+import static java.nio.file.Files.exists;
+import static java.nio.file.Files.walk;
+
+@RequiredArgsConstructor
+public class ExternalVariablesResolver {
+    private final YamlObject variables;
+
+    public static ExternalVariablesResolver externalVariablesResolver(OsdfPaths paths) {
+        String externalPath = settingsFile(ConfigsSettings.class, paths.settings().configs()).getSettings().getExternalPath();
+        if (externalPath == null || !exists(Path.of(externalPath))) return new ExternalVariablesResolver(yaml(Map.of()));
+
+        return new ExternalVariablesResolver(yaml(Path.of(externalPath)));
+    }
+
+    public void resolve(Path path) {
+        try (Stream<Path> walk = walk(path)) {
+            walk.filter(Files::isRegularFile).forEach(this::injectVariables);
+        } catch (IOException e) {
+            throw new PossibleBugException("Can't list files at " + path, e);
+        }
+    }
+
+    private void injectVariables(Path file) {
+        String content = readAll(file);
+        while (true) {
+            int ind = content.indexOf("~external(");
+            if (ind == -1) break;
+            int startInd = content.indexOf("(", ind);
+            int commaInd = content.indexOf(",", ind);
+            int endInd = content.indexOf(")", ind);
+            String value = getValue(content, startInd, commaInd, endInd);
+            content = content.replace(content.substring(ind, endInd + 1), value);
+        }
+        writeStringToFile(file, content);
+    }
+
+    private String getValue(String content, int startInd, int commaInd, int endInd) {
+        String key = content.substring(startInd + 1, commaInd == -1 ? endInd : commaInd).trim();
+        String defaultValue = commaInd != -1 ? content.substring(commaInd + 1, endInd).trim() : null;
+        return Stream.of(variables.get(key), defaultValue)
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElseThrow(() -> new OSDFException("External variable required for " + key));
+    }
+}

--- a/src/main/java/io/osdf/core/local/configs/ConfigsSettings.java
+++ b/src/main/java/io/osdf/core/local/configs/ConfigsSettings.java
@@ -10,10 +10,7 @@ public class ConfigsSettings {
     private String env;
     private String projectVersion;
     private String group;
-
-    public boolean verify() {
-        return configsSource != null && env != null;
-    }
+    private String externalPath;
 
     @Override
     public String toString() {
@@ -23,6 +20,8 @@ public class ConfigsSettings {
                 (projectVersion == null ? "" :
                         "Project version: " + projectVersion + "\n") +
                 (group == null ? "" :
-                        "Group: " + group + "\n");
+                        "Group: " + group + "\n") +
+                (externalPath == null ? "" :
+                        "External variables: " + externalPath + "\n");
     }
 }

--- a/src/test/java/io/osdf/actions/init/InitializationApiImplTest.java
+++ b/src/test/java/io/osdf/actions/init/InitializationApiImplTest.java
@@ -57,7 +57,7 @@ class InitializationApiImplTest {
     @Test
     void buildIfEnvIsSet() throws IOException {
         initializationApi(context.getPaths(), cli).localConfigs(context.configsPath(), null);
-        initializationApi(context.getPaths(), cli).configs("dev", null);
+        initializationApi(context.getPaths(), cli).configs("dev", null, null);
         try (Stream<Path> files = list(context.getPaths().componentsPath())) {
             List<String> builtComponents = files.map(Path::getFileName)
                     .map(Path::toString)
@@ -70,12 +70,12 @@ class InitializationApiImplTest {
     @Test
     void exceptionIfEnvIsNotProvided() {
         initializationApi(context.getPaths(), cli).localConfigs(context.configsPath(), null);
-        assertThrows(OSDFException.class, () -> initializationApi(context.getPaths(), cli).configs(null, null));
+        assertThrows(OSDFException.class, () -> initializationApi(context.getPaths(), cli).configs(null, null, null));
     }
 
     @Test
     void exceptionIfBuildWithoutConfigs() {
-        assertThrows(OSDFException.class, () -> initializationApi(context.getPaths(), cli).configs("dev", null));
+        assertThrows(OSDFException.class, () -> initializationApi(context.getPaths(), cli).configs("dev", null, null));
     }
 
     @Test

--- a/src/test/java/io/osdf/actions/init/configs/postprocess/AppPostProcessorTest.java
+++ b/src/test/java/io/osdf/actions/init/configs/postprocess/AppPostProcessorTest.java
@@ -1,22 +1,32 @@
 package io.osdf.actions.init.configs.postprocess;
 
 import io.osdf.common.yaml.YamlObject;
+import io.osdf.context.TestContext;
 import io.osdf.core.local.component.ComponentDir;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static io.osdf.actions.init.configs.postprocess.AppPostProcessor.componentPostProcessor;
 import static io.osdf.common.yaml.YamlObject.yaml;
+import static io.osdf.context.TestContext.defaultContext;
 import static io.osdf.test.local.AppUtils.componentDirFor;
 import static java.nio.file.Files.exists;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AppPostProcessorTest {
+    private static final TestContext context = defaultContext();
+
+    @BeforeAll
+    static void initOsdf() {
+        context.initDev();
+    }
+
     @Test
     void testConfigMapIsCreated_WithoutResources() {
         ComponentDir componentDir = componentDirFor("configmap-plainApp");
 
-        componentPostProcessor().process(componentDir);
+        componentPostProcessor(context.getPaths()).process(componentDir);
 
         assertTrue(exists(componentDir.getPath("resources/configmap-app-configmap.yaml")));
     }
@@ -25,7 +35,7 @@ class AppPostProcessorTest {
     void testResourceTemplatePostProcessor() {
         ComponentDir componentDir = componentDirFor("with-template-engine-usage");
 
-        componentPostProcessor().process(componentDir);
+        componentPostProcessor(context.getPaths()).process(componentDir);
 
         YamlObject yaml = yaml(componentDir.getPath("resources/deployment.yaml"));
         assertNotNull(yaml.get("data.key"));

--- a/src/test/java/io/osdf/actions/init/configs/postprocess/ExternalVariablesResolverTest.java
+++ b/src/test/java/io/osdf/actions/init/configs/postprocess/ExternalVariablesResolverTest.java
@@ -1,0 +1,87 @@
+package io.osdf.actions.init.configs.postprocess;
+
+import io.osdf.actions.init.InitializationApiImpl;
+import io.osdf.actions.init.configs.postprocess.ExternalVariablesResolver;
+import io.osdf.common.exceptions.OSDFException;
+import io.osdf.context.TestContext;
+import io.osdf.core.connection.cli.ClusterCli;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static io.osdf.actions.init.InitializationApiImpl.initializationApi;
+import static io.osdf.actions.init.configs.postprocess.ExternalVariablesResolver.externalVariablesResolver;
+import static io.osdf.common.utils.FileUtils.readAll;
+import static io.osdf.common.utils.FileUtils.writeStringToFile;
+import static io.osdf.common.yaml.YamlObject.yaml;
+import static io.osdf.context.TestContext.defaultContext;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+class ExternalVariablesResolverTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void success() {
+        assertResolver(resolver(), "" +
+                "integer: ~external(integer.key)" + "\n" +
+                "string: ~external(string.key)" + "\n" +
+                "concat: ~external(integer.key)~external(string.key)", "" +
+
+                "integer: 1" + "\n" +
+                "string: test" + "\n" +
+                "concat: 1test");
+    }
+
+    @Test
+    void defaultValue() {
+        assertResolver(resolver(), "" +
+                "string: ~external(unknown.key, default)", "" +
+
+                "string: default");
+    }
+
+    @Test
+    void throwOsdfException_ifNoKey_and_noDefault() {
+        assertThrows(OSDFException.class, () ->
+                assertResolver(resolver(), "" +
+                        "string: ~external(unknown.key)", "" +
+
+                        "string: ?"));
+    }
+
+    @Test
+    void noErrors_ifExternalFileIsNotConfigured() {
+        TestContext context = defaultContext();
+        context.initDev();
+        assertResolver(externalVariablesResolver(context.getPaths()),
+                "this: ~external(other, default)", "this: default");
+    }
+
+    @Test
+    void noErrors_ifExternalFileIsNotFound() {
+        TestContext context = defaultContext();
+        context.initDev();
+        initializationApi(context.getPaths(), mock(ClusterCli.class)).configs(null, null, "unknown/file");
+        assertResolver(externalVariablesResolver(context.getPaths()),
+                "this: ~external(other, default)", "this: default");
+    }
+
+    private void assertResolver(ExternalVariablesResolver resolver, String from, String to) {
+        Path file = tempDir.resolve("file.yaml");
+        writeStringToFile(file, from);
+        resolver.resolve(tempDir);
+        assertEquals(to, readAll(file));
+    }
+
+    private ExternalVariablesResolver resolver() {
+        return new ExternalVariablesResolver(yaml("" +
+                "integer:" + "\n" +
+                "  key: 1" + "\n" +
+                "string:" + "\n" +
+                "  key: test"
+        ));
+    }
+}

--- a/src/test/java/io/osdf/actions/init/configs/postprocess/ResourceSplitterTest.java
+++ b/src/test/java/io/osdf/actions/init/configs/postprocess/ResourceSplitterTest.java
@@ -1,7 +1,9 @@
 package io.osdf.actions.init.configs.postprocess;
 
+import io.osdf.context.TestContext;
 import io.osdf.core.local.component.ComponentDir;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -9,6 +11,7 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import static io.osdf.actions.init.configs.postprocess.AppPostProcessor.componentPostProcessor;
+import static io.osdf.context.TestContext.defaultContext;
 import static io.osdf.test.ClasspathReader.classpathFile;
 import static io.osdf.test.local.AppUtils.componentDirFor;
 import static java.nio.file.Files.copy;
@@ -16,11 +19,18 @@ import static java.nio.file.Files.exists;
 import static java.util.List.of;
 
 class ResourceSplitterTest {
+    private static final TestContext context = defaultContext();
+
+    @BeforeAll
+    static void initOsdf() {
+        context.initDev();
+    }
+
     @Test
     void testSplitResources() throws IOException {
         ComponentDir componentDir = componentDirWithTestResource("deployment-and-service.yaml");
 
-        componentPostProcessor().process(componentDir);
+        componentPostProcessor(context.getPaths()).process(componentDir);
 
         assertSplit(Assertions::assertTrue, componentDir,
                 "deployment-and-service.yaml", of("Deployment-simple-service", "Service-simple-service")
@@ -31,7 +41,7 @@ class ResourceSplitterTest {
     void doNotSplitOnCommentedDashes() throws IOException {
         ComponentDir componentDir = componentDirWithTestResource("commented-split.yaml");
 
-        componentPostProcessor().process(componentDir);
+        componentPostProcessor(context.getPaths()).process(componentDir);
 
         assertSplit(Assertions::assertFalse, componentDir,
                 "commented-split.yaml", of("Kind1-name1", "Kind2-name2")
@@ -42,7 +52,7 @@ class ResourceSplitterTest {
     void splitWithEmptySplits() throws IOException {
         ComponentDir componentDir = componentDirWithTestResource("empty-splits.yaml");
 
-        componentPostProcessor().process(componentDir);
+        componentPostProcessor(context.getPaths()).process(componentDir);
 
         assertSplit(Assertions::assertTrue, componentDir,
                 "empty-splits.yaml", of("Kind1-name1", "Kind2-name2")
@@ -54,7 +64,7 @@ class ResourceSplitterTest {
         ComponentDir componentDir = componentDirFor("simple-service");
         copy(classpathFile("resources/deployment-and-service.yaml"), componentDir.getPath("resources/deployment-and-service.any"));
 
-        componentPostProcessor().process(componentDir);
+        componentPostProcessor(context.getPaths()).process(componentDir);
 
         assertSplit(Assertions::assertTrue, componentDir,
                 "deployment-and-service.any", of("Deployment-simple-service", "Service-simple-service")

--- a/src/test/java/io/osdf/context/TestContext.java
+++ b/src/test/java/io/osdf/context/TestContext.java
@@ -58,7 +58,7 @@ public class TestContext {
         prepareConfigs();
         initializationApi(paths, mock(ClusterCli.class)).openshift(of("user:pass"), null, false);
         initializationApi(paths, mock(ClusterCli.class)).localConfigs(configsPath(), null);
-        initializationApi(paths, mock(ClusterCli.class)).configs("dev", null);
+        initializationApi(paths, mock(ClusterCli.class)).configs("dev", null, null);
     }
 
     @SneakyThrows

--- a/src/test/java/io/osdf/core/local/microconfig/state/MicroConfigFilesStateTest.java
+++ b/src/test/java/io/osdf/core/local/microconfig/state/MicroConfigFilesStateTest.java
@@ -29,7 +29,7 @@ class MicroConfigFilesStateTest {
     void testOldFilesAndFoldersGetDeleted() throws IOException {
         Path pathToDeployConfig = of(context.getPaths().configsPath() + "/components/apps/simple-service/os.deploy");
         writeString(pathToDeployConfig, "some: value");
-        initializationApi(context.getPaths(), mock(ClusterCli.class)).configs(null, null);
+        initializationApi(context.getPaths(), mock(ClusterCli.class)).configs(null, null, null);
 
         assertTrue(exists(of(context.getPaths().componentsPath() + "/simple-service/application.yaml")));
         assertFalse(exists(of(context.getPaths().componentsPath() + "/simple-service/openshift")));


### PR DESCRIPTION
Support external variables injection.
Having these files
```
# external.yaml 

host: 10.10.10.10
```
```
# some file from configs

db.host: ~external(host)
```
The result after `osdf init configs -ext external.yaml && osdf pull` will be:
```
# some file from configs

db.host: 10.10.10.10
```

